### PR TITLE
Hotfix/deleting notifications

### DIFF
--- a/innopoints/models/account.py
+++ b/innopoints/models/account.py
@@ -86,5 +86,5 @@ class Transaction(db.Model):
     change = db.Column(db.Integer, nullable=False)
     stock_change_id = db.Column(db.Integer, db.ForeignKey('stock_changes.id'), nullable=True)
     feedback_id = db.Column(db.Integer,
-                            db.ForeignKey('feedback.application_id', ondelete='CASCADE'),
+                            db.ForeignKey('feedback.application_id', ondelete='SET NULL'),
                             nullable=True)

--- a/innopoints/views/activity.py
+++ b/innopoints/views/activity.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import IntegrityError
 from innopoints.extensions import db
 from innopoints.blueprints import api
 from innopoints.core.helpers import abort
+from innopoints.core.notifications import remove_notifications
 from innopoints.models import Activity, Project, IPTS_PER_HOUR, Competence, LifetimeStage
 from innopoints.schemas import ActivitySchema, CompetenceSchema
 
@@ -132,6 +133,9 @@ class ActivityAPI(MethodView):
 
         try:
             db.session.commit()
+            remove_notifications({
+                'activity_id': activity_id,
+            })
         except IntegrityError as err:
             db.session.rollback()
             log.exception(err)

--- a/innopoints/views/application.py
+++ b/innopoints/views/application.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 
 from innopoints.blueprints import api
 from innopoints.core.helpers import abort
-from innopoints.core.notifications import notify, notify_all
+from innopoints.core.notifications import notify, notify_all, remove_notifications
 from innopoints.core.timezone import tz_aware_now
 from innopoints.extensions import db
 from innopoints.models import (
@@ -108,6 +108,9 @@ def take_back_application(project_id, activity_id):
     db.session.delete(application)
     try:
         db.session.commit()
+        remove_notifications({
+            'application_id': application.id,
+        })
     except IntegrityError as err:
         db.session.rollback()
         log.exception(err)

--- a/innopoints/views/product.py
+++ b/innopoints/views/product.py
@@ -22,7 +22,7 @@ from sqlalchemy.exc import IntegrityError
 
 from innopoints.blueprints import api
 from innopoints.core.helpers import abort
-from innopoints.core.notifications import notify_all
+from innopoints.core.notifications import notify_all, remove_notifications
 from innopoints.extensions import db
 from innopoints.models import (
     Account,
@@ -245,6 +245,9 @@ class ProductDetailAPI(MethodView):
             db.session.rollback()
             log.exception(err)
             abort(400, {'message': 'Data integrity violated.'})
+        remove_notifications({
+            'product_id': product_id,
+        })
         return NO_PAYLOAD
 
 

--- a/innopoints/views/project.py
+++ b/innopoints/views/project.py
@@ -30,7 +30,7 @@ from sqlalchemy.exc import IntegrityError
 
 from innopoints.blueprints import api
 from innopoints.core.helpers import abort
-from innopoints.core.notifications import notify, notify_all
+from innopoints.core.notifications import notify, notify_all, remove_notifications
 from innopoints.extensions import db
 from innopoints.models import (
     Account,
@@ -519,6 +519,9 @@ class ProjectDetailAPI(MethodView):
             db.session.rollback()
             log.exception(err)
             abort(400, {'message': 'Data integrity violated.'})
+        remove_notifications({
+            'project_id': project_id,
+        })
         return NO_PAYLOAD
 
 

--- a/innopoints/views/project.py
+++ b/innopoints/views/project.py
@@ -509,6 +509,8 @@ class ProjectDetailAPI(MethodView):
         project = Project.query.get_or_404(project_id)
         if not current_user.is_admin and current_user != project.creator:
             abort(401)
+        if project.lifetime_stage == LifetimeStage.finished:
+            abort(400, {'message': 'Cannot delete a finished project'})
 
         try:
             db.session.delete(project)


### PR DESCRIPTION
On any endpoint that deletes an entity, delete any notification associated with that entity as the relation is not stored as a foreign key, but rather inside a JSON object