### PR TITLE
Disable autoflush for schema loading to prevent 500

### DIFF
--- a/innopoints/views/activity.py
+++ b/innopoints/views/activity.py
@@ -101,7 +101,8 @@ class ActivityAPI(MethodView):
         in_schema = ActivitySchema(exclude=('id', 'project', 'applications', 'internal'))
 
         try:
-            updated_activity = in_schema.load(request.json, instance=activity, partial=True)
+            with db.session.no_autoflush:
+                updated_activity = in_schema.load(request.json, instance=activity, partial=True)
         except ValidationError as err:
             abort(400, {'message': err.messages})
 


### PR DESCRIPTION
This is weird, but apparently the line:
```python
updated_activity = in_schema.load(request.json, instance=activity, partial=True)
```
had some querying effects somewhere in the middle of its workings, which meant that when you switch from `{fixed_reward: false, working_hours: 3, reward_rate: 70}` to `{fixed_reward: true, working_hours: 1, reward_rate: 720}`, a constraint violation happens, because somehow a query finds its way in between applying changes to `working_hours`, `reward_rate` and `fixed_reward`. This is to remedy that