### PR TITLE
Use numeric file IDs for images everywhere

### DIFF
--- a/innopoints/core/notifications/content.py
+++ b/innopoints/core/notifications/content.py
@@ -41,7 +41,7 @@ def get_content(type: NotificationType, payload: dict):
         title = 'Purchase status changed'
         link = f"/products/{payload['product'].id}"
         if payload['variety'].images:
-            image_src = payload['variety'].images[0]
+            image_src = f'/file/{payload["variety"].images[0].image_id}'
 
         body = ['Your ', str(payload['product']), ' purchase ']
 
@@ -107,7 +107,7 @@ def get_content(type: NotificationType, payload: dict):
         title = 'Out of stock'
         link = f"/products/{payload['product'].id}"
         if payload['variety'].images:
-            image_src = payload['variety'].images[0]
+            image_src = f'/file/{payload["variety"].images[0].image_id}'
         body = ['The ',
                 Link(title=str(payload['product']),
                      href=f"/products/{payload['product'].id}"),
@@ -116,7 +116,7 @@ def get_content(type: NotificationType, payload: dict):
         title = 'New purchase'
         link = '/dashboard'
         if payload['variety'].images:
-            image_src = payload['variety'].images[0]
+            image_src = f'/file/{payload["variety"].images[0].image_id}'
         body = [Link(title=payload['account'].full_name,
                      href='/profile?user=' + payload['account'].email),
                 ' has purchased the ',

--- a/innopoints/core/notifications/push.py
+++ b/innopoints/core/notifications/push.py
@@ -21,7 +21,6 @@ def remove_links(fragment):
     return fragment
 
 
-
 def push(recipient_email: str, notification_type: NotificationType, payload=None):
     '''Sends a notification to the specified user.'''
     subscriptions = Account.query.get(recipient_email).notification_settings.get('subscriptions')

--- a/innopoints/schemas/variety.py
+++ b/innopoints/schemas/variety.py
@@ -70,12 +70,12 @@ class VarietySchema(ma.SQLAlchemyAutoSchema):
         """Convert the array of URL strings to an array of image objects with order."""
         if self.context.get('update', False):
             if 'images' in data:
-                data['images'] = [{'order': idx, 'image_id': int(url.split('/')[2])}
-                                  for (idx, url) in enumerate(data['images'], start=1)]
+                data['images'] = [{'order': idx, 'image_id': id}
+                                  for (idx, id) in enumerate(data['images'], start=1)]
         else:
             try:
-                data['images'] = [{'order': idx, 'image_id': int(url.split('/')[2])}
-                                  for (idx, url) in enumerate(data['images'], start=1)]
+                data['images'] = [{'order': idx, 'image_id': id}
+                                  for (idx, id) in enumerate(data['images'], start=1)]
             except KeyError:
                 raise ValidationError('Images must be specified.')
         return data
@@ -93,7 +93,7 @@ class VarietySchema(ma.SQLAlchemyAutoSchema):
         if 'images' not in data:
             return data
 
-        data['images'] = [f'/file/{image["image_id"]}'
+        data['images'] = [image["image_id"]
                           for image in sorted(data['images'],
                                               key=lambda x: x['order'])]
         return data
@@ -115,6 +115,9 @@ class ColorSchema(ma.SQLAlchemyAutoSchema):
     @pre_load
     def normalize_value(self, data, **_kwargs):
         """Normalize the color value, stripping the '#' and transforming symbols to uppercase."""
+        if not isinstance(data.get('value'), str):
+            raise ValidationError('The value must be a string.')
+
         if data['value'].startswith('#'):
             data['value'] = data['value'][1:]
 


### PR DESCRIPTION
Previously varieties of products were outputting `images: ["/file/X", "/file/Y"], which is actually very weird and inconsistent, so this will transform them into numeric IDs.

This means changing the store page to handle this and, possibly, documentation.