### PR TITLE
Improve the image quality and resize the images correctly

### DIFF
--- a/innopoints/core/file_manager/local.py
+++ b/innopoints/core/file_manager/local.py
@@ -30,7 +30,7 @@ class FileManagerLocal:
         """Upload the given file with the handle."""
         filename = self._join_base(handle)
         if isinstance(file, Image.Image):
-            file.save(filename, format='WebP', quality=80)
+            file.save(filename, format='WebP', quality=100)
         else:
             file.save(filename)
 

--- a/innopoints/core/image.py
+++ b/innopoints/core/image.py
@@ -26,7 +26,7 @@ def crop(image: Image.Image, dimensions: Dict[str, str]):
         return image
 
 
-SQUARE_THRESHOLD = 416
+SQUARE_THRESHOLD = 832
 ANY_THRESHOLD = 1024
 
 def shrink(image: Image.Image):

--- a/innopoints/core/image.py
+++ b/innopoints/core/image.py
@@ -26,7 +26,7 @@ def crop(image: Image.Image, dimensions: Dict[str, str]):
         return image
 
 
-SQUARE_THRESHOLD = 512
+SQUARE_THRESHOLD = 416
 ANY_THRESHOLD = 1024
 
 def shrink(image: Image.Image):


### PR DESCRIPTION
About that writing on the GitHub shirt – unfortunately, at the size that we're showing the image (416x416) it is unreadable anyway, which is why I reduced the scaling size to 416 instead of increasing it to 1024 as you previously suggested.

You might argue that some people know how to "open the image in a new tab" to zoom in, which is true, but currently (perhaps due to a lacking nginx conf line) we are serving the WebP files without a proper mimetype, so the browser doesn't even recognize it as an image. That's why for now resizing to 416 is the best option. We'll still keep the original images in case we come up with something better at some point.